### PR TITLE
Improved build command readability

### DIFF
--- a/17/Dockerfile
+++ b/17/Dockerfile
@@ -4,12 +4,12 @@ ENV OTP_VERSION 17.5.6.4
 
 # We'll install the build dependencies for erlang-odbc along with the erlang
 # build process:
-RUN buildDeps='unixodbc-dev' \
+RUN  OTP_DOWNLOAD_SHA1=8436bbc750dc90580842e907f911255228d2d070 \
+  && buildDeps='unixodbc-dev' \
 	&& set -xe \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends $buildDeps \
 	&& mkdir -p /usr/src/otp-src \
-	&& OTP_DOWNLOAD_SHA1=8436bbc750dc90580842e907f911255228d2d070 \
 	&& curl -fSL -o otp-src.tar.gz "https://github.com/erlang/otp/archive/OTP-$OTP_VERSION.tar.gz" \
 	&& echo "$OTP_DOWNLOAD_SHA1 otp-src.tar.gz" | sha1sum -c - \
 	&& tar -xzf otp-src.tar.gz -C /usr/src/otp-src --strip-components=1 \

--- a/17/slim/Dockerfile
+++ b/17/slim/Dockerfile
@@ -4,7 +4,8 @@ ENV OTP_VERSION 17.5.6.4
 
 # We'll install the build dependencies, and purge them on the last step to make
 # sure our final image contains only what we've just built:
-RUN buildDeps=' \
+RUN  OTP_DOWNLOAD_SHA1=8436bbc750dc90580842e907f911255228d2d070 \
+  && buildDeps=' \
 		autoconf \
 		bison \
 		ca-certificates \
@@ -27,7 +28,6 @@ RUN buildDeps=' \
 	&& apt-get install -y --no-install-recommends $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/otp-src \
-	&& OTP_DOWNLOAD_SHA1=8436bbc750dc90580842e907f911255228d2d070 \
 	&& curl -fSL -o otp-src.tar.gz "https://github.com/erlang/otp/archive/OTP-$OTP_VERSION.tar.gz" \
 	&& echo "$OTP_DOWNLOAD_SHA1 otp-src.tar.gz" | sha1sum -c - \
 	&& tar -xzf otp-src.tar.gz -C /usr/src/otp-src --strip-components=1 \

--- a/18/Dockerfile
+++ b/18/Dockerfile
@@ -4,12 +4,12 @@ ENV OTP_VERSION 18.1.3
 
 # We'll install the build dependencies for erlang-odbc along with the erlang
 # build process:
-RUN buildDeps='unixodbc-dev' \
+RUN  OTP_DOWNLOAD_SHA1=981e6c03c0a310483e6c14edb7dd2acaa842e2f8 \
+	&& buildDeps='unixodbc-dev' \
 	&& set -xe \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends $buildDeps \
 	&& mkdir -p /usr/src/otp-src \
-	&& OTP_DOWNLOAD_SHA1=981e6c03c0a310483e6c14edb7dd2acaa842e2f8 \
 	&& curl -fSL -o otp-src.tar.gz "https://github.com/erlang/otp/archive/OTP-$OTP_VERSION.tar.gz" \
 	&& echo "$OTP_DOWNLOAD_SHA1 otp-src.tar.gz" | sha1sum -c - \
 	&& tar -xzf otp-src.tar.gz -C /usr/src/otp-src --strip-components=1 \

--- a/18/slim/Dockerfile
+++ b/18/slim/Dockerfile
@@ -4,7 +4,8 @@ ENV OTP_VERSION 18.1.3
 
 # We'll install the build dependencies, and purge them on the last step to make
 # sure our final image contains only what we've just built:
-RUN buildDeps=' \
+RUN  OTP_DOWNLOAD_SHA1=981e6c03c0a310483e6c14edb7dd2acaa842e2f8 \
+	&& buildDeps=' \
 		autoconf \
 		bison \
 		ca-certificates \
@@ -28,7 +29,6 @@ RUN buildDeps=' \
 	&& apt-get install -y --no-install-recommends $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /usr/src/otp-src \
-	&& OTP_DOWNLOAD_SHA1=981e6c03c0a310483e6c14edb7dd2acaa842e2f8 \
 	&& curl -fSL -o otp-src.tar.gz "https://github.com/erlang/otp/archive/OTP-$OTP_VERSION.tar.gz" \
 	&& echo "$OTP_DOWNLOAD_SHA1 otp-src.tar.gz" | sha1sum -c - \
 	&& tar -xzf otp-src.tar.gz -C /usr/src/otp-src --strip-components=1 \


### PR DESCRIPTION
Moved the download fingerprint to the top of the chained build commands, to improve readability, and making any change on it to be more evident (first lines un a chunk of code are more noticed than the last).

I read somewhere (yesterday) that the lines of code that tend to change more frequently in a Dockerfile should go first... but I can't find that reference.