### PR TITLE
the "generate-stackbrew-library.sh" for new 2822-based manifest file …

### DIFF
--- a/17/Dockerfile
+++ b/17/Dockerfile
@@ -1,6 +1,6 @@
 FROM buildpack-deps:jessie
 
-ENV OTP_VERSION=17.5.6.9
+ENV OTP_VERSION="17.5.6.9"
 
 # We'll install the build dependencies for erlang-odbc along with the erlang
 # build process:

--- a/17/slim/Dockerfile
+++ b/17/slim/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:jessie
 
-ENV OTP_VERSION=17.5.6.9
+ENV OTP_VERSION="17.5.6.9"
 
 # We'll install the build dependencies, and purge them on the last step to make
 # sure our final image contains only what we've just built:

--- a/19/Dockerfile
+++ b/19/Dockerfile
@@ -1,11 +1,11 @@
 FROM buildpack-deps:jessie
 
-ENV OTP_VERSION="OTP-19.0"
+ENV OTP_VERSION="19.0"
 
 # We'll install the build dependencies for erlang-odbc along with the erlang
 # build process:
 RUN set -xe \
-	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/${OTP_VERSION##*@}.tar.gz" \
+	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
 	&& OTP_DOWNLOAD_SHA256="107b629aa7aea1bf76df0197629a50ce4fea61143ebb0e9a1b633b1fbaf9beb7" \
 	&& runtimeDeps='libodbc1' \
 	&& buildDeps='unixodbc-dev' \
@@ -33,7 +33,7 @@ CMD ["erl"]
 ENV REBAR_VERSION="2.6.1"
 
 RUN set -xe \
-	&& REBAR_DOWNLOAD_URL="https://github.com/rebar/rebar/archive/${REBAR_VERSION##*@}.tar.gz" \
+	&& REBAR_DOWNLOAD_URL="https://github.com/rebar/rebar/archive/${REBAR_VERSION}.tar.gz" \
 	&& REBAR_DOWNLOAD_SHA256="aed933d4e60c4f11e0771ccdb4434cccdb9a71cf8b1363d17aaf863988b3ff60" \
 	&& mkdir -p /usr/src/rebar-src \
 	&& curl -fSL -o rebar-src.tar.gz "$REBAR_DOWNLOAD_URL" \
@@ -48,7 +48,7 @@ RUN set -xe \
 ENV REBAR3_VERSION="3.2.0"
 
 RUN set -xe \
-	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION##*@}.tar.gz" \
+	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
 	&& REBAR3_DOWNLOAD_SHA256="78ad27372eea6e215790e161ae46f451c107a58a019cc7fb4551487903516455" \
 	&& mkdir -p /usr/src/rebar3-src \
 	&& curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \

--- a/19/slim/Dockerfile
+++ b/19/slim/Dockerfile
@@ -1,11 +1,11 @@
 FROM debian:jessie
 
-ENV OTP_VERSION="OTP-19.0"
+ENV OTP_VERSION="19.0"
 
 # We'll install the build dependencies, and purge them on the last step to make
 # sure our final image contains only what we've just built:
 RUN set -xe \
-	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/${OTP_VERSION##*@}.tar.gz" \
+	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION##*@}.tar.gz" \
 	&& OTP_DOWNLOAD_SHA256="107b629aa7aea1bf76df0197629a50ce4fea61143ebb0e9a1b633b1fbaf9beb7" \
 	&& runtimeDeps=' \
 		libodbc1 \

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+set -eu
+
+declare -a -r versions=( 19 18 17 )
+declare -A -r aliases=(
+	[19]='latest'
+)
+
+# get the most recent commit which modified any of "$@"
+fileCommit() {
+	git log -1 --format='format:%H' HEAD -- "$@"
+}
+
+# get the most recent commit which modified "$1/Dockerfile" or any file COPY'd from "$1/Dockerfile"
+dirCommit() {
+	local dir="$1"; shift
+	(
+		cd "$dir"
+		fileCommit \
+			Dockerfile \
+			$(git show HEAD:./Dockerfile | awk '
+				toupper($1) == "COPY" {
+					for (i = 2; i < NF; i++) {
+						print $i
+					}
+				}
+			')
+	)
+}
+
+# prints "$2$1$3$1...$N"
+join() {
+	local sep="$1"; shift
+	local out; printf -v out "${sep//%/%%}%s" "$@"
+	echo "${out#$sep}"
+}
+
+self="${BASH_SOURCE##*/}"
+
+cat <<-EOH
+# this file is generated via https://github.com/c0b/docker-erlang-otp/blob/$(fileCommit "$self")/$self
+
+Maintainers: denc716@gmail.com (@c0b)
+GitRepo: https://github.com/c0b/docker-erlang-otp.git
+EOH
+
+for version in "${versions[@]}"; do
+	commit="$(dirCommit "$version")"
+
+	fullVersion="$(git show "$commit":"$version/Dockerfile" | awk '$1 == "ENV" { match($2, /OTP_VERSION="([0-9\.]+)"/, arr); print arr[1]; exit; }')"
+
+	versionAliases=( $fullVersion )
+	while :; do
+		localVersion="${fullVersion%.*}"
+		if [ "$localVersion" = "$fullVersion" ]; then
+			break
+		fi
+		versionAliases+=( $localVersion )
+		fullVersion=$localVersion
+		# echo "${versionAliases[@]}"
+	done
+	versionAliases+=( ${aliases[$version]:-} )
+
+	echo
+	cat <<-EOE
+		Tags: $(join ', ' "${versionAliases[@]}")
+		GitCommit: $commit
+		Directory: $version
+	EOE
+
+	for variant in slim onbuild; do
+		[ -f "$version/$variant/Dockerfile" ] || continue
+
+		commit="$(dirCommit "$version/$variant")"
+
+		variantAliases=( "${versionAliases[@]/%/-$variant}" )
+		variantAliases=( "${variantAliases[@]//latest-/}" )
+
+		echo
+		cat <<-EOE
+			Tags: $(join ', ' "${variantAliases[@]}")
+			GitCommit: $commit
+			Directory: $version/$variant
+		EOE
+	done
+done


### PR DESCRIPTION
Generate a new manifest file format like:

```console
# this file is generated via https://github.com/c0b/docker-erlang-otp/blob/93e01d92515d3863dc0310288afc6da5263e89be/generate-stackbrew-library.sh

Maintainers: denc716@gmail.com (@c0b)
GitRepo: https://github.com/c0b/docker-erlang-otp.git

Tags: 19.0, 19, latest
GitCommit: 93e01d92515d3863dc0310288afc6da5263e89be
Directory: 19

Tags: 19.0-slim, 19-slim, slim
GitCommit: 93e01d92515d3863dc0310288afc6da5263e89be
Directory: 19/slim

Tags: 19.0-onbuild, 19-onbuild, onbuild
GitCommit: 847b82cdb8896d8d865bf32f2833787b5c62587c
Directory: 19/onbuild

Tags: 18.3.4, 18.3, 18
GitCommit: aeae7ea95d8f42cb3c810fb962720235e304cb60
Directory: 18

Tags: 18.3.4-slim, 18.3-slim, 18-slim
GitCommit: aeae7ea95d8f42cb3c810fb962720235e304cb60
Directory: 18/slim

Tags: 18.3.4-onbuild, 18.3-onbuild, 18-onbuild
GitCommit: 20e41464075dc0fc76709be77701530eddb6fe33
Directory: 18/onbuild

Tags: 17.5.6.9, 17.5.6, 17.5, 17
GitCommit: 93e01d92515d3863dc0310288afc6da5263e89be
Directory: 17

Tags: 17.5.6.9-slim, 17.5.6-slim, 17.5-slim, 17-slim
GitCommit: 93e01d92515d3863dc0310288afc6da5263e89be
Directory: 17/slim

Tags: 17.5.6.9-onbuild, 17.5.6-onbuild, 17.5-onbuild, 17-onbuild
GitCommit: dbcb2dd16843db0663d10278f2a13cc70a840494
Directory: 17/onbuild
```

Inspired from the python docker-library with some changes
https://github.com/docker-library/python/blob/master/generate-stackbrew-library.sh