### PR TITLE
enable sctp support in OTP 19

### DIFF
--- a/19/Dockerfile
+++ b/19/Dockerfile
@@ -7,8 +7,10 @@ ENV OTP_VERSION="19.0"
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
 	&& OTP_DOWNLOAD_SHA256="107b629aa7aea1bf76df0197629a50ce4fea61143ebb0e9a1b633b1fbaf9beb7" \
-	&& runtimeDeps='libodbc1' \
-	&& buildDeps='unixodbc-dev' \
+	&& runtimeDeps='libodbc1 \
+			libsctp1' \
+	&& buildDeps='unixodbc-dev \
+			libsctp-dev' \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends $runtimeDeps \
 	&& apt-get install -y --no-install-recommends $buildDeps \
@@ -19,7 +21,7 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& cd /usr/src/otp-src \
 	&& ./otp_build autoconf \
-	&& ./configure \
+	&& ./configure --enable-sctp \
 	&& make -j$(nproc) \
 	&& make install \
 	&& find /usr/local -name examples | xargs rm -rf \

--- a/19/slim/Dockerfile
+++ b/19/slim/Dockerfile
@@ -10,6 +10,7 @@ RUN set -xe \
 	&& runtimeDeps=' \
 		libodbc1 \
 		libssl1.0.0 \
+		libsctp1 \
 	' \
 	&& buildDeps=' \
 		curl \
@@ -20,6 +21,7 @@ RUN set -xe \
 		libncurses-dev \
 		unixodbc-dev \
 		libssl-dev \
+		libsctp-dev \
 	' \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends $runtimeDeps \
@@ -31,7 +33,7 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& cd /usr/src/otp-src \
 	&& ./otp_build autoconf \
-	&& ./configure \
+	&& ./configure --enable-sctp \
 	&& make -j$(nproc) \
 	&& make install \
 	&& find /usr/local -name examples | xargs rm -rf \


### PR DESCRIPTION
enable sctp support
at runtime this will work only if the kernel of your host has sctp support

quick test to see if it works:
```
root@2e25e3a0f7b0:/# erl 
Erlang/OTP 19 [erts-8.0] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false]

Eshell V8.0  (abort with ^G)
1> gen_sctp:open() . 
{ok,#Port<0.441>}
2>
```