### PR TITLE
Update generated "Maintainers" line to match the upstream-expected format

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -50,7 +50,7 @@ self="${BASH_SOURCE##*/}"
 cat <<-EOH
 # this file is generated via https://github.com/c0b/docker-erlang-otp/blob/$(fileCommit "$self")/$self
 
-Maintainers: denc716@gmail.com (@c0b)
+Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
 GitRepo: https://github.com/c0b/docker-erlang-otp.git
 EOH
 


### PR DESCRIPTION
See also https://github.com/docker-library/official-images/pull/2042/files#diff-c9976a31b54be88c19792313c6647e6eL3 and https://github.com/docker-library/official-images/blob/master/README.md#instruction-format