### PR TITLE
version bump: otp-19.0.5 & 18.3.4.4

### DIFF
--- a/18/Dockerfile
+++ b/18/Dockerfile
@@ -1,12 +1,12 @@
 FROM buildpack-deps:jessie
 
-ENV OTP_VERSION="18.3.4.3"
+ENV OTP_VERSION="18.3.4.4"
 
 # We'll install the build dependencies for erlang-odbc along with the erlang
 # build process:
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-$OTP_VERSION.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="9cfb0315ae2650c3b1bb6f66f430753593f014698fd6105ef19cfd8eb90f72fe" \
+	&& OTP_DOWNLOAD_SHA256="3956f5c4fcd05848c7fe048d5c4ef7eaf002a8312cba0674150c5a10ab0e9f04" \
 	&& runtimeDeps='libodbc1 \
 			libsctp1' \
 	&& buildDeps='unixodbc-dev \

--- a/18/slim/Dockerfile
+++ b/18/slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM debian:jessie
 
-ENV OTP_VERSION="18.3.4.3"
+ENV OTP_VERSION="18.3.4.4"
 
 # We'll install the build dependencies, and purge them on the last step to make
 # sure our final image contains only what we've just built:
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-$OTP_VERSION.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="9cfb0315ae2650c3b1bb6f66f430753593f014698fd6105ef19cfd8eb90f72fe" \
+	&& OTP_DOWNLOAD_SHA256="3956f5c4fcd05848c7fe048d5c4ef7eaf002a8312cba0674150c5a10ab0e9f04" \
 	&& runtimeDeps=' \
 		libodbc1 \
 		libssl1.0.0 \

--- a/19/Dockerfile
+++ b/19/Dockerfile
@@ -1,12 +1,12 @@
 FROM buildpack-deps:jessie
 
-ENV OTP_VERSION="19.0.3"
+ENV OTP_VERSION="19.0.5"
 
 # We'll install the build dependencies for erlang-odbc along with the erlang
 # build process:
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="feb8c5fe111087443c90ce189b979b0288ba358ebffb9be18a99cc69719cacc8" \
+	&& OTP_DOWNLOAD_SHA256="1cf9e6e9519b7191607f37045a7660bb0c70c285bb591dd2b3fca62e06403540" \
 	&& runtimeDeps='libodbc1 \
 			libsctp1' \
 	&& buildDeps='unixodbc-dev \

--- a/19/slim/Dockerfile
+++ b/19/slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM debian:jessie
 
-ENV OTP_VERSION="19.0.3"
+ENV OTP_VERSION="19.0.5"
 
 # We'll install the build dependencies, and purge them on the last step to make
 # sure our final image contains only what we've just built:
 RUN set -xe \
-	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION##*@}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="feb8c5fe111087443c90ce189b979b0288ba358ebffb9be18a99cc69719cacc8" \
+	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
+	&& OTP_DOWNLOAD_SHA256="1cf9e6e9519b7191607f37045a7660bb0c70c285bb591dd2b3fca62e06403540" \
 	&& runtimeDeps=' \
 		libodbc1 \
 		libssl1.0.0 \


### PR DESCRIPTION
https://github.com/erlang/otp/releases

![image](https://cloud.githubusercontent.com/assets/14798161/17816697/6580271a-65ef-11e6-857c-e7c4a666eba5.png)
