### PR TITLE
Erlang OTP 19.1.5

### DIFF
--- a/19/Dockerfile
+++ b/19/Dockerfile
@@ -1,12 +1,12 @@
 FROM buildpack-deps:jessie
 
-ENV OTP_VERSION="19.1"
+ENV OTP_VERSION="19.1.5"
 
 # We'll install the build dependencies for erlang-odbc along with the erlang
 # build process:
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="caf320c07bdd4c6e11831a0b0d25645a29112007077dbf11eec22437f8b041ed" \
+	&& OTP_DOWNLOAD_SHA256="1de52d8292b9d1a1a146f888788d32ce9f1f3eec17a5db59d94d38d8e257c240" \
 	&& runtimeDeps='libodbc1 \
 			libsctp1' \
 	&& buildDeps='unixodbc-dev \
@@ -47,11 +47,11 @@ RUN set -xe \
 	&& install -v ./rebar /usr/local/bin/ \
 	&& rm -rf /usr/src/rebar-src
 
-ENV REBAR3_VERSION="3.3.1"
+ENV REBAR3_VERSION="3.3.2"
 
 RUN set -xe \
 	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
-	&& REBAR3_DOWNLOAD_SHA256="1042ffc90a723f57b9d5a6e3858c33e9c5230fe9ef0c51fafd6ce63618b4afe9" \
+	&& REBAR3_DOWNLOAD_SHA256="ccbc27355727090b1fdde7497ab2485c3509e2fd14b48a93276b285b5760d092" \
 	&& mkdir -p /usr/src/rebar3-src \
 	&& curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
 	&& echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \

--- a/19/slim/Dockerfile
+++ b/19/slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM debian:jessie
 
-ENV OTP_VERSION="19.1"
+ENV OTP_VERSION="19.1.5"
 
 # We'll install the build dependencies, and purge them on the last step to make
 # sure our final image contains only what we've just built:
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="caf320c07bdd4c6e11831a0b0d25645a29112007077dbf11eec22437f8b041ed" \
+	&& OTP_DOWNLOAD_SHA256="1de52d8292b9d1a1a146f888788d32ce9f1f3eec17a5db59d94d38d8e257c240" \
 	&& runtimeDeps=' \
 		libodbc1 \
 		libssl1.0.0 \


### PR DESCRIPTION
https://github.com/erlang/otp/releases/tag/OTP-19.1.5

tagged 3 days ago · 128 commits to maint since this tag

Changed Applications:
- ssh-4.3.6

Unchanged Applications:
- asn1-4.0.4
- common_test-1.12.3
- compiler-7.0.2
- cosEvent-2.2.1
- cosEventDomain-1.2.1
- cosFileTransfer-1.2.1
- cosNotification-1.2.2
- cosProperty-1.2.1
- cosTime-1.2.2
- cosTransactions-1.3.2
- crypto-3.7.1
- debugger-4.2.1
- dialyzer-3.0.2
- diameter-1.12.1
- edoc-0.8
- eldap-1.2.2
- erl_docgen-0.6
- erl_interface-3.9.1
- erts-8.1
- et-1.6
- eunit-2.3.1
- gs-1.6.2
- hipe-3.15.2
- ic-4.4.2
- inets-6.3.3
- jinterface-1.7.1
- kernel-5.1
- megaco-3.18.1
- mnesia-4.14.1
- observer-2.2.2
- odbc-2.11.3
- orber-3.8.2
- os_mon-2.4.1
- otp_mibs-1.1.1
- parsetools-2.1.3
- percept-0.9
- public_key-1.2
- reltool-0.7.2
- runtime_tools-1.10.1
- sasl-3.0.1
- snmp-5.2.4
- ssl-8.0.3
- stdlib-3.1
- syntax_tools-2.1
- tools-2.8.6
- typer-0.9.11
- wx-1.7.1
- xmerl-1.3.12
