### PR TITLE
Add support Erlang OTP 20 (20.0-rc1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,23 @@ language: bash
 services: docker
 
 env:
-  - VERSION=master VARIANT=
-  - VERSION=master VARIANT=alpine
-  - VERSION=19 VARIANT=
-  - VERSION=19 VARIANT=slim
-  - VERSION=18 VARIANT=
-  - VERSION=18 VARIANT=slim
-
-install:
-  - git clone https://github.com/docker-library/official-images.git ~/official-images
+  - DIR=master
+  - DIR=master VARIANT=alpine
+  - DIR=20
+  - DIR=20 VARIANT=slim
+  - DIR=20 VARIANT=alpine
+  - DIR=19
+  - DIR=19 VARIANT=slim
 
 before_script:
-  - env | sort
-  - cd "$VERSION"
-  - image="$(awk '$1 == "FROM" { print $2; exit }' onbuild/Dockerfile)${VARIANT:+-$VARIANT}"
+  - cd "$DIR"
+  - eval $(awk '/OTP_VERSION=/ { sub(/@/, "-", $2); print $2; exit }' ${VARIANT:-.}/Dockerfile)
+  - image="erlang:${OTP_VERSION}${VARIANT:+-$VARIANT}"
 
 script:
   - docker build --pull -t "$image" "${VARIANT:-.}"
-  - ~/official-images/test/run.sh "$image"
+  - curl -fsSL https://github.com/docker-library/official-images/archive/master.tar.gz | tar -zxvv official-images-master/test/
+  - ./official-images-master/test/run.sh "$image"
 
 after_script:
   - docker images

--- a/20/Dockerfile
+++ b/20/Dockerfile
@@ -1,0 +1,68 @@
+FROM buildpack-deps:jessie
+
+ENV OTP_VERSION="20.0-rc1"
+
+# We'll install the build dependencies for erlang-odbc along with the erlang
+# build process:
+RUN set -xe \
+	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
+	&& OTP_DOWNLOAD_SHA256="9d31979ea4f95553389910c74b8a709992697d8bc7ebeb9a65726d2bd97ab900" \
+	&& runtimeDeps='libodbc1 \
+			libsctp1 \
+			libwxgtk3.0-0' \
+	&& buildDeps='unixodbc-dev \
+			libsctp-dev \
+			libwxgtk3.0-dev' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $runtimeDeps \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& curl -fSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
+	&& echo "$OTP_DOWNLOAD_SHA256  otp-src.tar.gz" | sha256sum -c - \
+	&& export ERL_TOP="/usr/src/otp_src_${OTP_VERSION%%@*}" \
+	&& mkdir -vp $ERL_TOP \
+	&& tar -xzf otp-src.tar.gz -C $ERL_TOP --strip-components=1 \
+	&& rm otp-src.tar.gz \
+	&& ( cd $ERL_TOP \
+	  && echo "${OTP_VERSION}" > ./OTP_VERSION \
+	  && ./otp_build autoconf \
+	  && ./configure \
+		--enable-dirty-schedulers \
+	  && make -j$(nproc) \
+	  && make install ) \
+	&& find /usr/local -name examples | xargs rm -rf \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& rm -rf $ERL_TOP /var/lib/apt/lists/*
+
+CMD ["erl"]
+
+# extra useful tools here: rebar & rebar3
+
+ENV REBAR_VERSION="2.6.4"
+
+RUN set -xe \
+	&& REBAR_DOWNLOAD_URL="https://github.com/rebar/rebar/archive/${REBAR_VERSION}.tar.gz" \
+	&& REBAR_DOWNLOAD_SHA256="577246bafa2eb2b2c3f1d0c157408650446884555bf87901508ce71d5cc0bd07" \
+	&& mkdir -p /usr/src/rebar-src \
+	&& curl -fSL -o rebar-src.tar.gz "$REBAR_DOWNLOAD_URL" \
+	&& echo "$REBAR_DOWNLOAD_SHA256 rebar-src.tar.gz" | sha256sum -c - \
+	&& tar -xzf rebar-src.tar.gz -C /usr/src/rebar-src --strip-components=1 \
+	&& rm rebar-src.tar.gz \
+	&& cd /usr/src/rebar-src \
+	&& ./bootstrap \
+	&& install -v ./rebar /usr/local/bin/ \
+	&& rm -rf /usr/src/rebar-src
+
+ENV REBAR3_VERSION="3.3.6"
+
+RUN set -xe \
+	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
+	&& REBAR3_DOWNLOAD_SHA256="2a3a6f709433a11e3fca51cc106b66e0941e7e7067bbc3f8364cbbad0b40660e" \
+	&& mkdir -p /usr/src/rebar3-src \
+	&& curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
+	&& echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \
+	&& tar -xzf rebar3-src.tar.gz -C /usr/src/rebar3-src --strip-components=1 \
+	&& rm rebar3-src.tar.gz \
+	&& cd /usr/src/rebar3-src \
+	&& HOME=$PWD ./bootstrap \
+	&& install -v ./rebar3 /usr/local/bin/ \
+	&& rm -rf /usr/src/rebar3-src

--- a/20/alpine/Dockerfile
+++ b/20/alpine/Dockerfile
@@ -1,0 +1,50 @@
+FROM alpine:3.5
+
+ENV OTP_VERSION="20.0-rc1"
+
+RUN set -xe \
+	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
+	&& OTP_DOWNLOAD_SHA256="9d31979ea4f95553389910c74b8a709992697d8bc7ebeb9a65726d2bd97ab900" \
+	&& apk add --no-cache --virtual .build-deps \
+		gcc \
+		libc-dev \
+		make \
+		autoconf \
+		ncurses-dev \
+		curl \
+		tar \
+	&& curl -fSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
+	&& echo "$OTP_DOWNLOAD_SHA256  otp-src.tar.gz" | sha256sum -c - \
+	&& export ERL_TOP="/usr/src/otp_src_${OTP_VERSION%%@*}" \
+	&& mkdir -vp $ERL_TOP \
+	&& tar -xzf otp-src.tar.gz -C $ERL_TOP --strip-components=1 \
+	&& rm otp-src.tar.gz \
+	&& ( cd $ERL_TOP \
+	  && echo "${OTP_VERSION}" > ./OTP_VERSION \
+	  && ./otp_build autoconf \
+	  && export OTP_SMALL_BUILD=true \
+	  && ./configure \
+		--enable-dirty-schedulers \
+	  && make -j$(getconf _NPROCESSORS_ONLN) \
+	  && make install ) \
+	&& rm -rf $ERL_TOP \
+	&& find /usr/local -regex '/usr/local/lib/erlang/\(lib/\|erts-\).*/\(man\|doc\|src\|info\|include\|examples\)' | xargs rm -rf \
+	&& rm -rf /usr/local/lib/erlang/lib/*tools* \
+		/usr/local/lib/erlang/lib/*test* \
+		/usr/local/lib/erlang/usr \
+		/usr/local/lib/erlang/misc \
+		/usr/local/lib/erlang/erts*/lib/lib*.a \
+		/usr/local/lib/erlang/erts*/lib/internal \
+	&& scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /usr/local | xargs strip --strip-all \
+	&& scanelf --nobanner -E ET_DYN -BF '%F' --recursive /usr/local | xargs -r strip --strip-unneeded \
+	&& runDeps=$( \
+		scanelf --needed --nobanner --recursive /usr/local \
+			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+			| sort -u \
+			| xargs -r apk info --installed \
+			| sort -u \
+	) \
+	&& apk add --virtual .erlang-rundeps $runDeps \
+	&& apk del .build-deps
+
+CMD ["erl"]

--- a/20/slim/Dockerfile
+++ b/20/slim/Dockerfile
@@ -1,0 +1,48 @@
+FROM debian:jessie
+
+ENV OTP_VERSION="20.0-rc1"
+
+# We'll install the build dependencies, and purge them on the last step to make
+# sure our final image contains only what we've just built:
+RUN set -xe \
+	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
+	&& OTP_DOWNLOAD_SHA256="9d31979ea4f95553389910c74b8a709992697d8bc7ebeb9a65726d2bd97ab900" \
+	&& runtimeDeps=' \
+		libodbc1 \
+		libssl1.0.0 \
+		libsctp1 \
+		libwxgtk3.0-0 \
+	' \
+	&& buildDeps=' \
+		curl \
+		ca-certificates \
+		autoconf \
+		gcc \
+		make \
+		libncurses-dev \
+		unixodbc-dev \
+		libssl-dev \
+		libsctp-dev \
+		libwxgtk3.0-dev \
+	' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $runtimeDeps \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& curl -fSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
+	&& echo "$OTP_DOWNLOAD_SHA256  otp-src.tar.gz" | sha256sum -c - \
+	&& export ERL_TOP="/usr/src/otp_src_${OTP_VERSION%%@*}" \
+	&& mkdir -vp $ERL_TOP \
+	&& tar -xzf otp-src.tar.gz -C $ERL_TOP --strip-components=1 \
+	&& rm otp-src.tar.gz \
+	&& ( cd $ERL_TOP \
+	  && echo "${OTP_VERSION}" > ./OTP_VERSION \
+	  && ./otp_build autoconf \
+	  && ./configure \
+		--enable-dirty-schedulers \
+	  && make -j$(nproc) \
+	  && make install ) \
+	&& find /usr/local -name examples | xargs rm -rf \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& rm -rf $ERL_TOP /var/lib/apt/lists/*
+
+CMD ["erl"]

--- a/README.md
+++ b/README.md
@@ -9,33 +9,35 @@
 [![Build Status](https://travis-ci.org/c0b/docker-erlang-otp.svg?branch=master)](https://travis-ci.org/c0b/docker-erlang-otp)
 
 This is used as docker base image for Erlang OTP.
-The goal is to provide images for a few last erlang releases (currently 19 / 18 / 17), in close to full feature Erlang OTP, and relatively slim images. Support to R16 and R15 are provided in this repo on a best-effort basis, and not part of official-image effort in docker-library/official-images#1075 .
+The goal is to provide images for a few last erlang releases (currently 20 / 19 / 18), in close to full feature Erlang OTP, and relatively slim images. Support to 17, R16 and R15 are provided in this repo on a best-effort basis, and not part of official-image effort in docker-library/official-images#1075 .
 
-### use the Erlang 19
+### use the Erlang 20
 
-here is providing the latest Erlang 19 image; you may pull from official-images or build it locally:
+here is providing the latest Erlang 20 image; you may pull from official-images or build it locally:
 
 ```console
-$ docker build -t erlang:19.0 ./19
+$ docker build -t erlang:20.0-rc1 ./20
 [...]
-➸ docker run -it --rm erlang:19.0
-Erlang/OTP 19 [erts-8.0.2] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false]
+➸ docker run -it --rm erlang:20.0-rc1
+Erlang/OTP 20 [RELEASE CANDIDATE 1] [erts-9.0] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:10] [hipe] [kernel-poll:false]
 
-Eshell V8.0.2  (abort with ^G)
+Eshell V9.0  (abort with ^G)
 1> erlang:system_info(otp_release).
-"19"
-2> uptime().
-6 seconds
+"20"
+2> os:getenv().
+["PWD=/","REBAR3_VERSION=3.3.6",
+"ROOTDIR=/usr/local/lib/erlang","LANG=C.UTF-8",
+"PATH=/usr/local/lib/erlang/erts-9.0/bin:/usr/local/lib/erlang/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+"REBAR_VERSION=2.6.4","TERM=xterm",
+"BINDIR=/usr/local/lib/erlang/erts-9.0/bin","PROGNAME=erl",
+"EMU=beam","OTP_VERSION=20.0-rc1","HOME=/root",
+"HOSTNAME=9b1e7f4d7206"]
+3> 'hello_юникод_世界'.                                   % Erlang20 now support unicode in atom
+'hello_юникод_世界'
+4> io:format("~tp~n", [{'hello_юникод', <<"Hello, 世界; юникод"/utf8>>, "Hello, 世界; юникод"}]).
+{'hello_юникод',<<"Hello, 世界; юникод"/utf8>>,"Hello, 世界; юникод"}
 ok
-3> os:getenv().
-["PWD=/","REBAR3_VERSION=3.2.0",
- "ROOTDIR=/usr/local/lib/erlang",
- "PATH=/usr/local/lib/erlang/erts-8.0.2/bin:/usr/local/lib/erlang/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
- "REBAR_VERSION=2.6.2","TERM=xterm",
- "BINDIR=/usr/local/lib/erlang/erts-8.0.2/bin",
- "PROGNAME=erl","EMU=beam","OTP_VERSION=19.0.3","HOME=/root",
- "HOSTNAME=1c91a740c50a"]
-4>
+5>
 ```
 
 #### Features
@@ -44,74 +46,53 @@ ok
    for different OSes, for Linux it requires X11 protocol be properly setup
    this wiki has setup for Linux desktop for observer use in elixir, which also applies to Erlang
    https://github.com/c0b/docker-elixir/wiki/use-observer
-2. dirty scheduler is enabled in Erlang 19 images;
+2. dirty scheduler is enabled since Erlang 19 images;
 
 Read from https://github.com/erlang/otp/releases for each tag description as release annoucement.
 
 ### Design
 
-1. the standard variant `erlang:19` `erlang:18`, `erlang:17`, builds from source code,
-   based on [buildpack-deps:jessie](https://hub.docker.com/_/buildpack-deps/);
-   it covered gcc compiler and some popular -dev packages, for those erlang port drivers written in C; while it doesn't have java compiler so jinterface doesn't compile, wxwidgets depends on some gl/gtk headers/lib also doesn't compile; here is assuming that to run GUI applications in docker is not popular, so here can save some space; jinterface is similar, the java dependencies are too fat, assuming demand to write java code for erlang applications is low;
-2. the -onbuild variant for each erlang version, to utilize ONBUILD instruction from Dockerfile, those are for starters
+1. the standard variant `erlang:20`, `erlang:19`, `erlang:18`, builds from source code,
+   based on [`buildpack-deps:jessie`](https://hub.docker.com/_/buildpack-deps/);
+   it covered gcc compiler and some popular -dev packages, for those erlang port drivers written in C; while it doesn't have java compiler so jinterface doesn't compile, assuming demand to write java code for erlang applications is low;
+2. the `-onbuild` variant is deprecated, due to docker-library/official-images#2076
 3. the slim version is built from `debian:jessie` install building tools (compilers & -dev packages) on the fly and uninstall after compilation finished, to shrink image size;
-4. rebar and rebar3 tool is bundled in `erlang:19` and `erlang:18` image, for `-onbuild` images to do something interesting;
+4. the alpine version is built from last alpine stable image, install building tools (compilers & -dev packages) on the fly and uninstall after compilation finished, also removed src/\*.erl include/\*.hrl / all docs (include man info) / examples / static archives / build and unittest tools, and strip the ELF binaries, to get a really slim image, ideally smaller than 20MB;
+5. rebar and rebar3 tool is bundled in `erlang:20`, `erlang:19` and `erlang:18` image;
 
 ### Sizes
 
 ```console
-$ docker images |grep ^erlang
-REPOSITORY TAG         IMAGE ID       CREATED          SIZE
-erlang     19.0        abfb7f7bad3a   48 minutes ago   750.6 MB
-erlang     19.0-slim   5aba9752dbd6   36 minutes ago   286.6 MB
-erlang     18.3        d7ca420db287   21 minutes ago   749.8 MB
-erlang     18.3-slim   cfeb2e9a2d9e   29 minutes ago   285.8 MB
-erlang     17.8-slim   e1fd9f4c9328   7 weeks ago      285.6 MB
-erlang     19.0-rc2    7c7178e1d074   8 weeks ago      759.4 MB
-erlang     19.0-x32    a7bff53623ba   2 minutes ago    699.4 MB
-erlang     19.0-rc0    448ce5129d08   7 minutes ago    742.5 MB
-erlang     18.2        907bbcb7b07f   43 minutes ago   744.8 MB
-erlang     18.2-slim   f4f63e4ef62d   27 hours ago     283.9 MB
-erlang     17.5-slim   16948ef75f5f   43 hours ago     280.7 MB
-erlang     17.5        d16f45f04f42   43 hours ago     740.2 MB
-erlang     18.2-slim   8db47440816d   43 hours ago     283.9 MB
-erlang     18.2-x32    fe555fc315ae   2 days ago       700.3 MB
-erlang     18.1-slim   0d2ef515fa92   21 minutes ago   283.6 MB
-erlang     18.1        57cd51bedc4b   35 minutes ago   742.9 MB
+$ docker images --filter=reference='erlang:*'
+REPOSITORY TAG             IMAGE ID       CREATED          SIZE
+erlang     20.0-rc1        84eea457a726   2 seconds ago    809.7 MB
+erlang     20.0-rc1-alpine dd870a4a2424   9 minutes ago    18.9 MB
+erlang     20.0-rc1-slim   50391255ea5a   14 minutes ago   362.2 MB
+erlang     19.3            2216344f0c70   32 hours ago     821.4 MB
+erlang     19.3-slim       11724662809a   31 hours ago     374.9 MB
+erlang     18.3            9f92145c1fac   10 days ago      754.3 MB
+erlang     18.3-slim       6d15a17b95d4   11 days ago      284.5 MB
 ```
 
 ### Running
 
 ```console
-$ docker run -it --rm erlang:19.0
-Erlang/OTP 19 [erts-8.0.2] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false]
-
-Eshell V8.0.2  (abort with ^G)
-1> uptime().
-7 seconds
-ok
-2> application:which_applications().
-[{stdlib,"ERTS  CXC 138 10","3.0.1"},
- {kernel,"ERTS  CXC 138 10","5.0.1"}]
-3>            # use Ctrl-G to call out shell menu to quit
-User switch command
- --> q
-$ docker run -it --rm erlang:19.0 /bin/bash
-root@cdf69caa9ff9:/# ls /usr/local/lib/erlang/lib/
-asn1-4.0.3             dialyzer-3.0.1     inets-6.3.2       reltool-0.7.1
-common_test-1.12.2     diameter-1.12      kernel-5.0.1      runtime_tools-1.10
-compiler-7.0.1         edoc-0.7.19        megaco-3.18.1     sasl-3.0
-cosEvent-2.2.1         eldap-1.2.2        mnesia-4.14       snmp-5.2.3
-cosEventDomain-1.2.1   erl_docgen-0.5     observer-2.2.1    ssh-4.3.1
-cosFileTransfer-1.2.1  erl_interface-3.9  odbc-2.11.2       ssl-8.0.1
-cosNotification-1.2.2  erts-8.0.2         orber-3.8.2       stdlib-3.0.1
-cosProperty-1.2.1      et-1.6             os_mon-2.4.1      syntax_tools-2.0
-cosTime-1.2.2          eunit-2.3          otp_mibs-1.1.1    tools-2.8.5
-cosTransactions-1.3.2  gs-1.6.1           parsetools-2.1.2  typer-0.9.11
-crypto-3.7             hipe-3.15.1        percept-0.9       wx-1.7
-debugger-4.2           ic-4.4.1           public_key-1.2    xmerl-1.3.11
-root@cdf69caa9ff9:/# ls /usr/local/lib/erlang/lib/ |wc -l
-48
+$ docker run -it --rm erlang:20.0-rc1 /bin/bash
+root@11ecefc83eb5:/# ls /usr/local/lib/erlang/lib/
+asn1-5.0              dialyzer-3.2       kernel-5.3         sasl-3.0.4
+common_test-1.15      diameter-1.12.3    megaco-3.18.2      snmp-5.2.5
+compiler-7.1          edoc-0.9           mnesia-4.15        ssh-4.5
+cosEvent-2.2.1        eldap-1.2.2        observer-2.4       ssl-8.2
+cosEventDomain-1.2.1  erl_docgen-0.7     odbc-2.12          stdlib-3.4
+cosFileTransfer-1.2.1 erl_interface-3.10 orber-3.8.3        syntax_tools-2.1.2
+cosNotification-1.2.2 erts-9.0           os_mon-2.4.2       tools-2.10
+cosProperty-1.2.2     et-1.6             otp_mibs-1.1.1     wx-1.8.1
+cosTime-1.2.2         eunit-2.3.3        parsetools-2.1.5   xmerl-1.3.14
+cosTransactions-1.3.2 hipe-3.16          public_key-1.4.1
+crypto-4.0            ic-4.4.2           reltool-0.7.3
+debugger-4.2.2        inets-6.3.9        runtime_tools-1.12
+root@11ecefc83eb5:/# ls /usr/local/lib/erlang/lib/ | wc -l
+45
 ```
 
-The official release 19 https://github.com/erlang/otp/tree/maint-19/lib has 48 libs, while here by default it provided 47 of them (plus erts-8.0.2 from erlang itself), except jinterface, because to build that one would pull all jdk dependencies and make this image too fat, it's just avoided here; if you really need that to write code in java and interface into erlang code, you may create an issue for this project.
+The official release 20 https://github.com/erlang/otp/tree/maint-20/lib has 45 libs, while here by default it provided 44 of them (plus erts-9.0 from erlang itself), except jinterface, because to build that one would pull all jdk dependencies and make the image too fat; if you really need that to write code in java and interface into erlang code, you may create an issue here to ask for it.


### PR DESCRIPTION
now provides 3 variants:
1. the regular developer friendly: `buildpack-deps:jessie` based,
   which is `debian:jessie` based, plus GNU C compiler and building tools and header files,
   and curl for downloading, source code management tools (bzr, git, hg, and svn),
   build and install erlang from source code;
2. the slim is `debian:jessie` based, build and install erlang from source code,
   and then remove the building tools for slim image size;
3. the alpine image is Apline Linux image based, build erlang from source code,
   this provides a really small image (<20MB).