### PR TITLE
Fix issue with exit signals

### DIFF
--- a/17/Dockerfile
+++ b/17/Dockerfile
@@ -26,4 +26,14 @@ RUN set -xe \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& rm -rf /usr/src/otp-src /var/lib/apt/lists/*
 
+
+ENV DUMBINIT_VERSION="1.2.0"
+
+RUN set -xe \
+	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& chmod +x /usr/local/bin/dumb-init
+
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+
 CMD ["erl"]

--- a/17/Dockerfile
+++ b/17/Dockerfile
@@ -31,7 +31,9 @@ ENV DUMBINIT_VERSION="1.2.0"
 
 RUN set -xe \
 	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& DUMBINIT_DOWNLOAD_SHA256=81231da1cd074fdc81af62789fead8641ef3f24b6b07366a1c34e5b059faf363 \
 	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& echo "$DUMBINIT_DOWNLOAD_SHA256  /usr/local/bin/dumb-init" | sha256sum -c - \
 	&& chmod +x /usr/local/bin/dumb-init
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]

--- a/17/slim/Dockerfile
+++ b/17/slim/Dockerfile
@@ -38,4 +38,13 @@ RUN set -xe \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& rm -rf /usr/src/otp-src /var/lib/apt/lists/*
 
+ENV DUMBINIT_VERSION="1.2.0"
+
+RUN set -xe \
+	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& chmod +x /usr/local/bin/dumb-init
+
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+
 CMD ["erl"]

--- a/17/slim/Dockerfile
+++ b/17/slim/Dockerfile
@@ -42,7 +42,9 @@ ENV DUMBINIT_VERSION="1.2.0"
 
 RUN set -xe \
 	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& DUMBINIT_DOWNLOAD_SHA256=81231da1cd074fdc81af62789fead8641ef3f24b6b07366a1c34e5b059faf363 \
 	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& echo "$DUMBINIT_DOWNLOAD_SHA256  /usr/local/bin/dumb-init" | sha256sum -c - \
 	&& chmod +x /usr/local/bin/dumb-init
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]

--- a/18/Dockerfile
+++ b/18/Dockerfile
@@ -61,3 +61,12 @@ RUN set -xe \
 	&& HOME=$PWD ./bootstrap \
 	&& install -v ./rebar3 /usr/local/bin/ \
 	&& rm -rf /usr/src/rebar3-src
+
+ENV DUMBINIT_VERSION="1.2.0"
+
+RUN set -xe \
+	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& chmod +x /usr/local/bin/dumb-init
+
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]

--- a/18/Dockerfile
+++ b/18/Dockerfile
@@ -66,7 +66,9 @@ ENV DUMBINIT_VERSION="1.2.0"
 
 RUN set -xe \
 	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& DUMBINIT_DOWNLOAD_SHA256=81231da1cd074fdc81af62789fead8641ef3f24b6b07366a1c34e5b059faf363 \
 	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& echo "$DUMBINIT_DOWNLOAD_SHA256  /usr/local/bin/dumb-init" | sha256sum -c - \
 	&& chmod +x /usr/local/bin/dumb-init
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]

--- a/18/slim/Dockerfile
+++ b/18/slim/Dockerfile
@@ -44,7 +44,9 @@ ENV DUMBINIT_VERSION="1.2.0"
 
 RUN set -xe \
 	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& DUMBINIT_DOWNLOAD_SHA256=81231da1cd074fdc81af62789fead8641ef3f24b6b07366a1c34e5b059faf363 \
 	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& echo "$DUMBINIT_DOWNLOAD_SHA256  /usr/local/bin/dumb-init" | sha256sum -c - \
 	&& chmod +x /usr/local/bin/dumb-init
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]

--- a/18/slim/Dockerfile
+++ b/18/slim/Dockerfile
@@ -40,4 +40,13 @@ RUN set -xe \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& rm -rf /usr/src/otp-src /var/lib/apt/lists/*
 
+ENV DUMBINIT_VERSION="1.2.0"
+
+RUN set -xe \
+	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& chmod +x /usr/local/bin/dumb-init
+
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+
 CMD ["erl"]

--- a/19/Dockerfile
+++ b/19/Dockerfile
@@ -70,7 +70,9 @@ ENV DUMBINIT_VERSION="1.2.0"
 
 RUN set -xe \
 	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& DUMBINIT_DOWNLOAD_SHA256=81231da1cd074fdc81af62789fead8641ef3f24b6b07366a1c34e5b059faf363 \
 	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& echo "$DUMBINIT_DOWNLOAD_SHA256  /usr/local/bin/dumb-init" | sha256sum -c - \
 	&& chmod +x /usr/local/bin/dumb-init
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]

--- a/19/Dockerfile
+++ b/19/Dockerfile
@@ -65,3 +65,12 @@ RUN set -xe \
 	&& HOME=$PWD ./bootstrap \
 	&& install -v ./rebar3 /usr/local/bin/ \
 	&& rm -rf /usr/src/rebar3-src
+
+ENV DUMBINIT_VERSION="1.2.0"
+
+RUN set -xe \
+	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& chmod +x /usr/local/bin/dumb-init
+
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]

--- a/19/slim/Dockerfile
+++ b/19/slim/Dockerfile
@@ -44,4 +44,14 @@ RUN set -xe \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& rm -rf /usr/src/otp-src /var/lib/apt/lists/*
 
+
+ENV DUMBINIT_VERSION="1.2.0"
+
+RUN set -xe \
+	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& chmod +x /usr/local/bin/dumb-init
+
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+
 CMD ["erl"]

--- a/19/slim/Dockerfile
+++ b/19/slim/Dockerfile
@@ -49,8 +49,14 @@ ENV DUMBINIT_VERSION="1.2.0"
 
 RUN set -xe \
 	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& DUMBINIT_DOWNLOAD_SHA256=81231da1cd074fdc81af62789fead8641ef3f24b6b07366a1c34e5b059faf363 \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends curl ca-certificates \
 	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
-	&& chmod +x /usr/local/bin/dumb-init
+	&& echo "$DUMBINIT_DOWNLOAD_SHA256  /usr/local/bin/dumb-init" | sha256sum -c - \
+	&& chmod +x /usr/local/bin/dumb-init \
+	&& apt-get purge -y --auto-remove curl ca-certificates \
+	&& rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 

--- a/20/Dockerfile
+++ b/20/Dockerfile
@@ -70,7 +70,9 @@ ENV DUMBINIT_VERSION="1.2.0"
 
 RUN set -xe \
 	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& DUMBINIT_DOWNLOAD_SHA256=81231da1cd074fdc81af62789fead8641ef3f24b6b07366a1c34e5b059faf363 \
 	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& echo "$DUMBINIT_DOWNLOAD_SHA256  /usr/local/bin/dumb-init" | sha256sum -c - \
 	&& chmod +x /usr/local/bin/dumb-init
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]

--- a/20/Dockerfile
+++ b/20/Dockerfile
@@ -65,3 +65,12 @@ RUN set -xe \
 	&& HOME=$PWD ./bootstrap \
 	&& install -v ./rebar3 /usr/local/bin/ \
 	&& rm -rf /usr/src/rebar3-src
+
+ENV DUMBINIT_VERSION="1.2.0"
+
+RUN set -xe \
+	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& chmod +x /usr/local/bin/dumb-init
+
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]

--- a/20/alpine/Dockerfile
+++ b/20/alpine/Dockerfile
@@ -52,7 +52,12 @@ ENV DUMBINIT_VERSION="1.2.0"
 
 RUN set -xe \
 	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& DUMBINIT_DOWNLOAD_SHA256=81231da1cd074fdc81af62789fead8641ef3f24b6b07366a1c34e5b059faf363 \
+	&& apk add --no-cache --virtual .fetch-deps \
+		curl \
+		ca-certificates \
 	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& echo "$DUMBINIT_DOWNLOAD_SHA256  /usr/local/bin/dumb-init" | sha256sum -c - \
 	&& chmod +x /usr/local/bin/dumb-init
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]

--- a/20/alpine/Dockerfile
+++ b/20/alpine/Dockerfile
@@ -48,4 +48,13 @@ RUN set -xe \
 	&& apk add --virtual .erlang-rundeps $runDeps \
 	&& apk del .fetch-deps .build-deps
 
+ENV DUMBINIT_VERSION="1.2.0"
+
+RUN set -xe \
+	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& chmod +x /usr/local/bin/dumb-init
+
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+
 CMD ["erl"]

--- a/20/slim/Dockerfile
+++ b/20/slim/Dockerfile
@@ -52,8 +52,14 @@ ENV DUMBINIT_VERSION="1.2.0"
 
 RUN set -xe \
 	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& DUMBINIT_DOWNLOAD_SHA256=81231da1cd074fdc81af62789fead8641ef3f24b6b07366a1c34e5b059faf363 \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends curl ca-certificates \
 	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
-	&& chmod +x /usr/local/bin/dumb-init
+	&& echo "$DUMBINIT_DOWNLOAD_SHA256  /usr/local/bin/dumb-init" | sha256sum -c - \
+	&& chmod +x /usr/local/bin/dumb-init \
+	&& apt-get purge -y --auto-remove curl ca-certificates \
+	&& rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 

--- a/20/slim/Dockerfile
+++ b/20/slim/Dockerfile
@@ -48,4 +48,13 @@ RUN set -xe \
 	&& apt-get purge -y --auto-remove $buildDeps $fetchDeps \
 	&& rm -rf $ERL_TOP /var/lib/apt/lists/*
 
+ENV DUMBINIT_VERSION="1.2.0"
+
+RUN set -xe \
+	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& chmod +x /usr/local/bin/dumb-init
+
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+
 CMD ["erl"]

--- a/R15/Dockerfile
+++ b/R15/Dockerfile
@@ -19,4 +19,13 @@ RUN set -xe \
 	&& find /usr/local -name examples | xargs rm -rf \
 	&& rm -rf /usr/src/otp-src
 
+ENV DUMBINIT_VERSION="1.2.0"
+
+RUN set -xe \
+	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& chmod +x /usr/local/bin/dumb-init
+
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+
 CMD ["erl"]

--- a/R15/Dockerfile
+++ b/R15/Dockerfile
@@ -23,7 +23,9 @@ ENV DUMBINIT_VERSION="1.2.0"
 
 RUN set -xe \
 	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& DUMBINIT_DOWNLOAD_SHA256=81231da1cd074fdc81af62789fead8641ef3f24b6b07366a1c34e5b059faf363 \
 	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& echo "$DUMBINIT_DOWNLOAD_SHA256  /usr/local/bin/dumb-init" | sha256sum -c - \
 	&& chmod +x /usr/local/bin/dumb-init
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]

--- a/R16/Dockerfile
+++ b/R16/Dockerfile
@@ -20,4 +20,13 @@ RUN set -xe \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& rm -rf /usr/src/otp-src /var/lib/apt/lists/*
 
+ENV DUMBINIT_VERSION="1.2.0"
+
+RUN set -xe \
+	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& chmod +x /usr/local/bin/dumb-init
+
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+
 CMD ["erl"]

--- a/R16/Dockerfile
+++ b/R16/Dockerfile
@@ -24,7 +24,9 @@ ENV DUMBINIT_VERSION="1.2.0"
 
 RUN set -xe \
 	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& DUMBINIT_DOWNLOAD_SHA256=81231da1cd074fdc81af62789fead8641ef3f24b6b07366a1c34e5b059faf363 \
 	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& echo "$DUMBINIT_DOWNLOAD_SHA256  /usr/local/bin/dumb-init" | sha256sum -c - \
 	&& chmod +x /usr/local/bin/dumb-init
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -72,7 +72,9 @@ ENV DUMBINIT_VERSION="1.2.0"
 
 RUN set -xe \
 	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& DUMBINIT_DOWNLOAD_SHA256=81231da1cd074fdc81af62789fead8641ef3f24b6b07366a1c34e5b059faf363 \
 	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& echo "$DUMBINIT_DOWNLOAD_SHA256  /usr/local/bin/dumb-init" | sha256sum -c - \
 	&& chmod +x /usr/local/bin/dumb-init
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -67,3 +67,12 @@ RUN set -xe \
 	&& HOME=$PWD ./bootstrap \
 	&& install -v ./rebar3 /usr/local/bin/ \
 	&& rm -rf /usr/src/rebar3-src
+
+ENV DUMBINIT_VERSION="1.2.0"
+
+RUN set -xe \
+	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& chmod +x /usr/local/bin/dumb-init
+
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]

--- a/master/alpine/Dockerfile
+++ b/master/alpine/Dockerfile
@@ -50,4 +50,18 @@ RUN set -xe \
 	&& apk add --virtual .erlang-rundeps $runDeps \
 	&& apk del .fetch-deps .build-deps
 
+ENV DUMBINIT_VERSION="1.2.0"
+
+RUN set -xe \
+	&& DUMBINIT_DOWNLOAD_URL="https://github.com/Yelp/dumb-init/releases/download/v${DUMBINIT_VERSION}/dumb-init_${DUMBINIT_VERSION}_amd64" \
+	&& DUMBINIT_DOWNLOAD_SHA256=81231da1cd074fdc81af62789fead8641ef3f24b6b07366a1c34e5b059faf363 \
+	&& apk add --no-cache --virtual .fetch-deps \
+		curl \
+		ca-certificates \
+	&& curl -fSL -o /usr/local/bin/dumb-init "$DUMBINIT_DOWNLOAD_URL" \
+	&& echo "$DUMBINIT_DOWNLOAD_SHA256  /usr/local/bin/dumb-init" | sha256sum -c - \
+	&& chmod +x /usr/local/bin/dumb-init
+
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+
 CMD ["erl"]


### PR DESCRIPTION
rebar3 (and old versions of Erlang) can't handle exit signals properly when running in containers.

To reproduce this error you can run the following command on a rebar-based project:
```bash
docker run --rm -it -v $(pwd):$(pwd) -w $(pwd) erlang:19.1 rebar3 shell"
```
CTRL+C will not work. To detach from the Erlang shell you will be tempted to run CTRL+P+Q, but that leaves the container running in the background.

More information about the general issue can be found here:
https://medium.com/@gchudnov/trapping-signals-in-docker-containers-7a57fdda7d86

This PR fixes the issue by means of using [dumb-init](https://github.com/Yelp/dumb-init) as the default entry point of the container. Meaning that the execution of all commands is wrapped in dumb-init.