### PR TITLE
build a full featured erlang:alpine image

### DIFF
--- a/20/alpine/Dockerfile
+++ b/20/alpine/Dockerfile
@@ -16,6 +16,7 @@ RUN set -xe \
 		make \
 		autoconf \
 		ncurses-dev \
+		openssl-dev \
 		tar \
 	&& export ERL_TOP="/usr/src/otp_src_${OTP_VERSION%%@*}" \
 	&& mkdir -vp $ERL_TOP \
@@ -23,19 +24,15 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& ( cd $ERL_TOP \
 	  && ./otp_build autoconf \
-	  && export OTP_SMALL_BUILD=true \
 	  && ./configure \
-		--enable-dirty-schedulers \
 	  && make -j$(getconf _NPROCESSORS_ONLN) \
 	  && make install ) \
 	&& rm -rf $ERL_TOP \
-	&& find /usr/local -regex '/usr/local/lib/erlang/\(lib/\|erts-\).*/\(man\|doc\|src\|info\|include\|examples\)' | xargs rm -rf \
-	&& rm -rf /usr/local/lib/erlang/lib/*tools* \
-		/usr/local/lib/erlang/lib/*test* \
-		/usr/local/lib/erlang/usr \
-		/usr/local/lib/erlang/misc \
+	&& find /usr/local -regex '/usr/local/lib/erlang/\(lib/\|erts-\).*/\(man\|doc\|src\|obj\|c_src\|emacs\|info\|examples\)' | xargs rm -rf \
+	&& rm -rf \
 		/usr/local/lib/erlang/erts*/lib/lib*.a \
-		/usr/local/lib/erlang/erts*/lib/internal \
+		/usr/local/lib/erlang/usr/lib/lib*.a \
+		/usr/local/lib/erlang/lib/*/lib/lib*.a \
 	&& scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /usr/local | xargs strip --strip-all \
 	&& scanelf --nobanner -E ET_DYN -BF '%F' --recursive /usr/local | xargs -r strip --strip-unneeded \
 	&& runDeps=$( \

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -1,12 +1,12 @@
 FROM buildpack-deps:jessie
 
-ENV OTP_VERSION="20.0-rc2@b833a06"
+ENV OTP_VERSION="21.0-rc0@72d994d"
 
 # We'll install the build dependencies for erlang-odbc along with the erlang
 # build process:
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/${OTP_VERSION#*@}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="ae89c2228eb1d8e868138610e0eb5fe2490557e186273d8e12eb94daf7f4c443" \
+	&& OTP_DOWNLOAD_SHA256="16bf8476b2c681f92a9595d3520a6f77c0f8eaf8efea6181147516d026b82fbf" \
 	&& curl -fSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
 	&& echo "$OTP_DOWNLOAD_SHA256 otp-src.tar.gz" | sha256sum -c - \
 	&& runtimeDeps='libodbc1 \
@@ -27,7 +27,6 @@ RUN set -xe \
 	  && sed -i -e '/utils\/gen_git_version/c\\\
 	@echo GIT_VSN=-DERLANG_GIT_VERSION="\\"\\\\\\""'${OTP_VERSION#*@}'\\\\"\\"\\"" > $@' ./erts/emulator/Makefile.in \
 	  && ./configure \
-		--enable-dirty-schedulers \
 	  && make -j$(nproc) \
 	  && make install ) \
 	&& find /usr/local -name examples | xargs rm -rf \
@@ -53,11 +52,11 @@ RUN set -xe \
 	&& install -v ./rebar /usr/local/bin/ \
 	&& rm -rf /usr/src/rebar-src
 
-ENV REBAR3_VERSION="3.4.1"
+ENV REBAR3_VERSION="3.4.2"
 
 RUN set -xe \
 	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
-	&& REBAR3_DOWNLOAD_SHA256="fa8b056c37ed3781728baf0fc5b1d87a31edbc5f8dd9b50a5d1ad92b0230e5dd" \
+	&& REBAR3_DOWNLOAD_SHA256="f4d38d01671af6a7eb4777654d1543b42c873dad32046e444434c64d929fc789" \
 	&& curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
 	&& echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/src/rebar3-src \

--- a/master/alpine/Dockerfile
+++ b/master/alpine/Dockerfile
@@ -1,10 +1,10 @@
 FROM alpine:3.6
 
-ENV OTP_VERSION="20.0-rc2@b833a06"
+ENV OTP_VERSION="21.0-rc0@72d994d"
 
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/${OTP_VERSION#*@}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="ae89c2228eb1d8e868138610e0eb5fe2490557e186273d8e12eb94daf7f4c443" \
+	&& OTP_DOWNLOAD_SHA256="16bf8476b2c681f92a9595d3520a6f77c0f8eaf8efea6181147516d026b82fbf" \
 	&& apk add --no-cache --virtual .fetch-deps \
 		curl \
 		ca-certificates \
@@ -16,6 +16,7 @@ RUN set -xe \
 		make \
 		autoconf \
 		ncurses-dev \
+		openssl-dev \
 		tar \
 	&& export ERL_TOP="/usr/src/otp_src_${OTP_VERSION%@*}" \
 	&& mkdir -vp $ERL_TOP \
@@ -25,19 +26,15 @@ RUN set -xe \
 	  && ./otp_build autoconf \
 	  && sed -i -e '/utils\/gen_git_version/c\\\
 	@echo GIT_VSN=-DERLANG_GIT_VERSION="\\"\\\\\\""'${OTP_VERSION#*@}'\\\\"\\"\\"" > $@' ./erts/emulator/Makefile.in \
-	  && export OTP_SMALL_BUILD=true \
 	  && ./configure \
-		--enable-dirty-schedulers \
 	  && make -j$(getconf _NPROCESSORS_ONLN) \
 	  && make install ) \
 	&& rm -rf $ERL_TOP \
-	&& find /usr/local -regex '/usr/local/lib/erlang/\(lib/\|erts-\).*/\(man\|doc\|src\|info\|include\|examples\)' | xargs rm -rf \
-	&& rm -rf /usr/local/lib/erlang/lib/*tools* \
-		/usr/local/lib/erlang/lib/*test* \
-		/usr/local/lib/erlang/usr \
-		/usr/local/lib/erlang/misc \
+	&& find /usr/local -regex '/usr/local/lib/erlang/\(lib/\|erts-\).*/\(man\|doc\|src\|obj\|c_src\|emacs\|info\|examples\)' | xargs rm -rf \
+	&& rm -rf \
 		/usr/local/lib/erlang/erts*/lib/lib*.a \
-		/usr/local/lib/erlang/erts*/lib/internal \
+		/usr/local/lib/erlang/usr/lib/lib*.a \
+		/usr/local/lib/erlang/lib/*/lib/lib*.a \
 	&& scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /usr/local | xargs strip --strip-all \
 	&& scanelf --nobanner -E ET_DYN -BF '%F' --recursive /usr/local | xargs -r strip --strip-unneeded \
 	&& runDeps=$( \


### PR DESCRIPTION
to keep image size under 30MB is unrealistic, but to build full featured erlang
has more benefits; image size is between 60~70MB now.

comparing with 45 builtin erlang apps (https://github.com/erlang/otp/tree/master/lib)
now the alpine image has 42 of them, missing ones are jinterface, orber, odbc.

the dirty scheduler is enabled by default since 20, hence this configure switch can be removed.

closes #58 #57