### PR TITLE
master update: add unixodbc and sctp support in alpine

### DIFF
--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -1,12 +1,12 @@
 FROM buildpack-deps:jessie
 
-ENV OTP_VERSION="21.0-rc0@72d994d"
+ENV OTP_VERSION="21.0-rc0@fdce942"
 
 # We'll install the build dependencies for erlang-odbc along with the erlang
 # build process:
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/${OTP_VERSION#*@}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="16bf8476b2c681f92a9595d3520a6f77c0f8eaf8efea6181147516d026b82fbf" \
+	&& OTP_DOWNLOAD_SHA256="7f92f4bcb49066992349e5929551d08368e979d8fe5bbac4fb282a165177fade" \
 	&& curl -fSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
 	&& echo "$OTP_DOWNLOAD_SHA256 otp-src.tar.gz" | sha256sum -c - \
 	&& runtimeDeps='libodbc1 \

--- a/master/alpine/Dockerfile
+++ b/master/alpine/Dockerfile
@@ -1,22 +1,23 @@
 FROM alpine:3.6
 
-ENV OTP_VERSION="21.0-rc0@72d994d"
+ENV OTP_VERSION="21.0-rc0@fdce942"
 
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/${OTP_VERSION#*@}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="16bf8476b2c681f92a9595d3520a6f77c0f8eaf8efea6181147516d026b82fbf" \
+	&& OTP_DOWNLOAD_SHA256="7f92f4bcb49066992349e5929551d08368e979d8fe5bbac4fb282a165177fade" \
 	&& apk add --no-cache --virtual .fetch-deps \
 		curl \
 		ca-certificates \
 	&& curl -fSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
 	&& echo "$OTP_DOWNLOAD_SHA256  otp-src.tar.gz" | sha256sum -c - \
 	&& apk add --no-cache --virtual .build-deps \
-		gcc \
-		libc-dev \
-		make \
+		build-base \
+		linux-headers \
 		autoconf \
 		ncurses-dev \
 		openssl-dev \
+		unixodbc-dev \
+		lksctp-tools-dev \
 		tar \
 	&& export ERL_TOP="/usr/src/otp_src_${OTP_VERSION%@*}" \
 	&& mkdir -vp $ERL_TOP \
@@ -44,7 +45,7 @@ RUN set -xe \
 			| xargs -r apk info --installed \
 			| sort -u \
 	) \
-	&& apk add --virtual .erlang-rundeps $runDeps \
+	&& apk add --virtual .erlang-rundeps lksctp-tools $runDeps \
 	&& apk del .fetch-deps .build-deps
 
 CMD ["erl"]


### PR DESCRIPTION
the standard erlang otp distribution comes with 45 apps under lib,
here provide 44 of them, without jinterface for java dependency,
now it has all apps same as the debian based `erlang:latest`;
image size is at 68.18 MB.

```console
$ docker run -it --rm otp:21.0-rc0-fdce942-alpine sh
/ # ls /usr/local/lib/erlang/lib/
asn1-5.0.1             eldap-1.2.2            os_mon-2.4.2
common_test-1.15.1     erl_docgen-0.7         otp_mibs-1.1.1
compiler-7.1           erl_interface-3.10     parsetools-2.1.5
cosEvent-2.2.1         erts-9.0.2             public_key-1.4.1
cosEventDomain-1.2.1   et-1.6                 reltool-0.7.4
cosFileTransfer-1.2.1  eunit-2.3.3            runtime_tools-1.12.1
cosNotification-1.2.2  hipe-3.16              sasl-3.0.4
cosProperty-1.2.2      ic-4.4.2               snmp-5.2.6
cosTime-1.2.2          inets-6.4              ssh-4.5
cosTransactions-1.3.2  kernel-5.3.1           ssl-8.2
crypto-4.0             megaco-3.18.2          stdlib-3.4.1
debugger-4.2.2         mnesia-4.15            syntax_tools-2.1.2
dialyzer-3.2           observer-2.4           tools-2.10.1
diameter-2.0           odbc-2.12              wx-1.8.1
edoc-0.9               orber-3.8.3            xmerl-1.3.15
/ # ls /usr/local/lib/erlang/lib/ | wc -l
45
```