### PR TITLE
Keep all erlang libs private header file in Alpine

### DIFF
--- a/20/alpine/Dockerfile
+++ b/20/alpine/Dockerfile
@@ -28,7 +28,9 @@ RUN set -xe \
 	  && make -j$(getconf _NPROCESSORS_ONLN) \
 	  && make install ) \
 	&& rm -rf $ERL_TOP \
-	&& find /usr/local -regex '/usr/local/lib/erlang/\(lib/\|erts-\).*/\(man\|doc\|src\|obj\|c_src\|emacs\|info\|examples\)' | xargs rm -rf \
+	&& find /usr/local -regex '/usr/local/lib/erlang/\(lib/\|erts-\).*/\(man\|doc\|obj\|c_src\|emacs\|info\|examples\)' | xargs rm -rf \
+	&& find /usr/local -name src | xargs -r find | grep -v '\.hrl$' | xargs rm -v || true \
+	&& find /usr/local -name src | xargs -r find | xargs rmdir -vp || true \
 	&& rm -rf \
 		/usr/local/lib/erlang/erts*/lib/lib*.a \
 		/usr/local/lib/erlang/usr/lib/lib*.a \


### PR DESCRIPTION
From OTP Design Principles \\ 7.4  Directory Structure
http://erlang.org/doc/design_principles/applications.html#id81280

    include/ - Optional. Used for public include files that must be reachable from other applications.

Ideally, all public header files for other applications should be placed in the `include/` directory,
and src/ can contain *.erl source code, and private header files are ok kept under src/;

However in practice, some standard app is not following the convention,
like `<ssl/src/ssl_api.hrl>` is designed as a public header file, but
already referenced by many 3rd party applications (like `rabbit_common`)
https://github.com/erlang/otp/blob/master/lib/ssl/src/ssl_api.hrl

So the workaround is to keep all private header files, there's no
statistics how many other private header files are also used as public ones;
resolves #39