### PR TITLE
Add support for multiple architectures

### DIFF
--- a/17/Dockerfile
+++ b/17/Dockerfile
@@ -19,7 +19,8 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& cd /usr/src/otp-src \
 	&& ./otp_build autoconf \
-	&& ./configure \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure --build="$gnuArch" \
 	&& make -j$(nproc) \
 	&& make install \
 	&& find /usr/local -name examples | xargs rm -rf \

--- a/17/slim/Dockerfile
+++ b/17/slim/Dockerfile
@@ -15,6 +15,7 @@ RUN set -xe \
 		curl \
 		ca-certificates \
 		autoconf \
+		dpkg-dev \
 		gcc \
 		make \
 		libncurses-dev \
@@ -31,7 +32,8 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& cd /usr/src/otp-src \
 	&& ./otp_build autoconf \
-	&& ./configure \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure --build="$gnuArch" \
 	&& make -j$(nproc) \
 	&& make install \
 	&& find /usr/local -name examples | xargs rm -rf \

--- a/18/Dockerfile
+++ b/18/Dockerfile
@@ -21,7 +21,8 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& cd /usr/src/otp-src \
 	&& ./otp_build autoconf \
-	&& ./configure --enable-sctp \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure --build="$gnuArch" --enable-sctp \
 	&& make -j$(nproc) \
 	&& make install \
 	&& find /usr/local -name examples | xargs rm -rf \

--- a/18/slim/Dockerfile
+++ b/18/slim/Dockerfile
@@ -16,6 +16,7 @@ RUN set -xe \
 		curl \
 		ca-certificates \
 		autoconf \
+		dpkg-dev \
 		gcc \
 		make \
 		libncurses-dev \
@@ -33,7 +34,8 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& cd /usr/src/otp-src \
 	&& ./otp_build autoconf \
-	&& ./configure --enable-sctp \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure --build="$gnuArch" --enable-sctp \
 	&& make -j$(nproc) \
 	&& make install \
 	&& find /usr/local -name examples | xargs rm -rf \

--- a/19/Dockerfile
+++ b/19/Dockerfile
@@ -23,7 +23,8 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& cd /usr/src/otp-src \
 	&& ./otp_build autoconf \
-	&& ./configure \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure --build="$gnuArch" \
 		--enable-dirty-schedulers \
 	&& make -j$(nproc) \
 	&& make install \

--- a/19/slim/Dockerfile
+++ b/19/slim/Dockerfile
@@ -17,6 +17,7 @@ RUN set -xe \
 		curl \
 		ca-certificates \
 		autoconf \
+		dpkg-dev \
 		gcc \
 		make \
 		libncurses-dev \
@@ -35,7 +36,8 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& cd /usr/src/otp-src \
 	&& ./otp_build autoconf \
-	&& ./configure \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure --build="$gnuArch" \
 		--enable-dirty-schedulers \
 	&& make -j$(nproc) \
 	&& make install \

--- a/20/Dockerfile
+++ b/20/Dockerfile
@@ -24,7 +24,8 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& ( cd $ERL_TOP \
 	  && ./otp_build autoconf \
-	  && ./configure \
+	  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	  && ./configure --build="$gnuArch" \
 	  && make -j$(nproc) \
 	  && make install ) \
 	&& find /usr/local -name examples | xargs rm -rf \

--- a/20/alpine/Dockerfile
+++ b/20/alpine/Dockerfile
@@ -11,6 +11,7 @@ RUN set -xe \
 	&& curl -fSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
 	&& echo "$OTP_DOWNLOAD_SHA256  otp-src.tar.gz" | sha256sum -c - \
 	&& apk add --no-cache --virtual .build-deps \
+		dpkg-dev dpkg \
 		gcc \
 		g++ \
 		libc-dev \
@@ -28,7 +29,8 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& ( cd $ERL_TOP \
 	  && ./otp_build autoconf \
-	  && ./configure \
+	  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	  && ./configure --build="$gnuArch" \
 	  && make -j$(getconf _NPROCESSORS_ONLN) \
 	  && make install ) \
 	&& rm -rf $ERL_TOP \
@@ -39,7 +41,7 @@ RUN set -xe \
 		/usr/local/lib/erlang/erts*/lib/lib*.a \
 		/usr/local/lib/erlang/usr/lib/lib*.a \
 		/usr/local/lib/erlang/lib/*/lib/lib*.a \
-	&& scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /usr/local | xargs strip --strip-all \
+	&& scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /usr/local | xargs -r strip --strip-all \
 	&& scanelf --nobanner -E ET_DYN -BF '%F' --recursive /usr/local | xargs -r strip --strip-unneeded \
 	&& runDeps=$( \
 		scanelf --needed --nobanner --recursive /usr/local \

--- a/20/slim/Dockerfile
+++ b/20/slim/Dockerfile
@@ -21,6 +21,7 @@ RUN set -xe \
 	' \
 	&& buildDeps=' \
 		autoconf \
+		dpkg-dev \
 		gcc \
 		g++ \
 		make \
@@ -39,7 +40,8 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& ( cd $ERL_TOP \
 	  && ./otp_build autoconf \
-	  && ./configure \
+	  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	  && ./configure --build="$gnuArch" \
 	  && make -j$(nproc) \
 	  && make install ) \
 	&& find /usr/local -name examples | xargs rm -rf \

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -26,7 +26,8 @@ RUN set -xe \
 	  && ./otp_build autoconf \
 	  && sed -i -e '/utils\/gen_git_version/c\\\
 	@echo GIT_VSN=-DERLANG_GIT_VERSION="\\"\\\\\\""'${OTP_VERSION#*@}'\\\\"\\"\\"" > $@' ./erts/emulator/Makefile.in \
-	  && ./configure \
+	  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	  && ./configure --build="$gnuArch" \
 	  && make -j$(nproc) \
 	  && make install ) \
 	&& find /usr/local -name examples | xargs rm -rf \

--- a/master/alpine/Dockerfile
+++ b/master/alpine/Dockerfile
@@ -12,6 +12,7 @@ RUN set -xe \
 	&& echo "$OTP_DOWNLOAD_SHA256  otp-src.tar.gz" | sha256sum -c - \
 	&& apk add --no-cache --virtual .build-deps \
 		build-base \
+		dpkg-dev dpkg \
 		linux-headers \
 		autoconf \
 		ncurses-dev \
@@ -27,7 +28,8 @@ RUN set -xe \
 	  && ./otp_build autoconf \
 	  && sed -i -e '/utils\/gen_git_version/c\\\
 	@echo GIT_VSN=-DERLANG_GIT_VERSION="\\"\\\\\\""'${OTP_VERSION#*@}'\\\\"\\"\\"" > $@' ./erts/emulator/Makefile.in \
-	  && ./configure \
+	  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	  && ./configure --build="$gnuArch" \
 	  && make -j$(getconf _NPROCESSORS_ONLN) \
 	  && make install ) \
 	&& rm -rf $ERL_TOP \
@@ -36,7 +38,7 @@ RUN set -xe \
 		/usr/local/lib/erlang/erts*/lib/lib*.a \
 		/usr/local/lib/erlang/usr/lib/lib*.a \
 		/usr/local/lib/erlang/lib/*/lib/lib*.a \
-	&& scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /usr/local | xargs strip --strip-all \
+	&& scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /usr/local | xargs -r strip --strip-all \
 	&& scanelf --nobanner -E ET_DYN -BF '%F' --recursive /usr/local | xargs -r strip --strip-unneeded \
 	&& runDeps=$( \
 		scanelf --needed --nobanner --recursive /usr/local \


### PR DESCRIPTION
This uses `dpkg-architecture` to get the proper GNU tuple value for passing to `--build` on `./configure` invocations (which some arches can work without, but doing things like building 32bit images on 64bit kernels will break).  This is along the same lines as https://github.com/docker-library/gcc/pull/34 (and all the other PRs linked from that one).

For some reason, versions 18 and 19 do not build successfully on ppc64le, so I've excluded those combinations explicitly in `generate-stackbrew-library.sh` (with a comment noting the error received -- I also tried updating `config.guess` and `config.sub` in-place for those versions to see if that helps, and it does not, so I figured we might as well just exclude those from the support matrix instead since 17 and 20 both work fine).

This also includes the changes necessary to support the Alpine variants with proper multiarch once the upstream image is officially built that way (and the results of that for each architecture are also included below using the existing hacked-together Alpine images).  See https://github.com/gliderlabs/docker-alpine/issues/304 for the upstream issue tracking that change.

Here's the results from build testing this on each architecture:

`amd64`:

```
TAG            IMAGE ID      SIZE
17             1dd549b7ffa3  748MB
17-slim        6fbc2145c5f3  281MB
18             7e3e5c4a9f20  754MB
18-slim        5df9e72a4ef2  284MB
19             24ba3cb6c065  821MB
19-slim        1ad3a1c97322  375MB
20             24d24bceae50  874MB
20-alpine      297db53a7f3b  70.2MB
20-slim        ff9f8003c780  277MB
master         802a5a8bb530  809MB
master-alpine  a53503afc07e  68.2MB
```

`arm32v7`:

```
TAG      IMAGE ID      SIZE
17       df60315b83a1  616MB
17-slim  5a8c8979ba0e  242MB
18       c39107e65fb2  621MB
18-slim  af17963b4999  245MB
19       b6af577ba752  674MB
19-slim  8eca11cda0c3  319MB
20       d821b51ff4dc  728MB
20-slim  b1d2883c690e  240MB
master   1146f759e4ab  665MB
```

`arm64v8`:

```
TAG            IMAGE ID      SIZE
17             08c6e606c334  692MB
17-slim        24fc927a7eb3  269MB
18             c120c119bd84  698MB
18-slim        4f5d59a1a13f  272MB
19             60cc4c096f79  764MB
19-slim        86329f73c8e9  359MB
20             1a000e5163d7  817MB
20-alpine      f747d5abe1d7  65.6MB
20-slim        a77cbccb4422  265MB
master         1f1697a61c72  752MB
master-alpine  097e8165db40  63.6MB
```

`i386`:

```
TAG            IMAGE ID      SIZE
17             fac39a4759d0  734 MB
17-slim        83b2b2655733  283 MB
18             03347312d01b  740 MB
18-slim        496088b5ff70  287 MB
19             7f762ce50f2c  803 MB
19-slim        2c49447c0479  377 MB
20             24aaa2505fc5  855 MB
20-alpine      cad3f87c1031  69.9 MB
20-slim        21b805e82d04  282 MB
master         de2d23b1d874  794 MB
master-alpine  83db03d437ab  67.9 MB
```

`s390x`:

```
TAG            IMAGE ID      SIZE
17             fe358d304581  728MB
17-slim        eabdc152d3ff  287MB
18             63ef88c695e2  734MB
18-slim        0c7b31edc27f  290MB
19             a5fedc3365b6  806MB
19-slim        9b01eb0db543  386MB
20             0df5ebfae4f7  859MB
20-alpine      5eaba6a4bac2  67.9MB
20-slim        8b8583668671  282MB
master         0446b22ce6ac  792MB
master-alpine  be3a98bf8969  65.9MB
```

`ppc64le`:

```
TAG            IMAGE ID      SIZE
17             479b69dfb8e4  752MB
17-slim        2250cc40ef1a  286MB
20             3e9fb910771a  885MB
20-alpine      20fa16b73284  70.8MB
20-slim        7d451df78433  281MB
master         b2676b68fc79  819MB
master-alpine  2e6b99a7ee67  68.8MB
```