### PR TITLE
leave libraries used to build applications

### DIFF
--- a/20/alpine/Dockerfile
+++ b/20/alpine/Dockerfile
@@ -37,10 +37,6 @@ RUN set -xe \
 	&& find /usr/local -regex '/usr/local/lib/erlang/\(lib/\|erts-\).*/\(man\|doc\|obj\|c_src\|emacs\|info\|examples\)' | xargs rm -rf \
 	&& find /usr/local -name src | xargs -r find | grep -v '\.hrl$' | xargs rm -v || true \
 	&& find /usr/local -name src | xargs -r find | xargs rmdir -vp || true \
-	&& rm -rf \
-		/usr/local/lib/erlang/erts*/lib/lib*.a \
-		/usr/local/lib/erlang/usr/lib/lib*.a \
-		/usr/local/lib/erlang/lib/*/lib/lib*.a \
 	&& scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /usr/local | xargs -r strip --strip-all \
 	&& scanelf --nobanner -E ET_DYN -BF '%F' --recursive /usr/local | xargs -r strip --strip-unneeded \
 	&& runDeps=$( \


### PR DESCRIPTION
This patch drops the removal of those `.a` library archives. 

I ran into this issue trying to switch to the official Erlang alpine images for this project https://github.com/spacetime-iot/presence-sample to test it. 