### PR TITLE
Update to Erlang OTP-19.3.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ env:
   - DIR=20 VARIANT=alpine
   - DIR=19
   - DIR=19 VARIANT=slim
-  - DIR=18
-  - DIR=18 VARIANT=slim
-  - DIR=17
-  - DIR=17 VARIANT=slim
 
 before_script:
   - cd "$DIR"

--- a/19/Dockerfile
+++ b/19/Dockerfile
@@ -1,15 +1,15 @@
 FROM buildpack-deps:jessie
 
-ENV OTP_VERSION="19.3.6.2"
+ENV OTP_VERSION="19.3.6.3"
 
 # We'll install the build dependencies for erlang-odbc along with the erlang
 # build process:
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="4d901d90eff9d0775870a2c0c97220cf77d1531be9c8a5d276a2e5516e146a4c" \
+	&& OTP_DOWNLOAD_SHA256="a49ed01eef434058b46dd08f9999332506f47118e87d9bdb740ca349dd0ad0b4" \
 	&& runtimeDeps='libodbc1 \
 			libsctp1 \
-			libwxgtk3.0-0' \
+			libwxgtk3.0' \
 	&& buildDeps='unixodbc-dev \
 			libsctp-dev \
 			libwxgtk3.0-dev' \

--- a/19/slim/Dockerfile
+++ b/19/slim/Dockerfile
@@ -1,17 +1,17 @@
 FROM debian:jessie
 
-ENV OTP_VERSION="19.3.6.2"
+ENV OTP_VERSION="19.3.6.3"
 
 # We'll install the build dependencies, and purge them on the last step to make
 # sure our final image contains only what we've just built:
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="4d901d90eff9d0775870a2c0c97220cf77d1531be9c8a5d276a2e5516e146a4c" \
+	&& OTP_DOWNLOAD_SHA256="a49ed01eef434058b46dd08f9999332506f47118e87d9bdb740ca349dd0ad0b4" \
 	&& runtimeDeps=' \
 		libodbc1 \
 		libssl1.0.0 \
 		libsctp1 \
-		libwxgtk3.0-0 \
+		libwxgtk3.0 \
 	' \
 	&& buildDeps=' \
 		curl \


### PR DESCRIPTION
also cut some old entries in `.travis.yml` to save some power, can add back anytime if 18 or 17 has new minor versions.