### PR TITLE
the Erlang OTP 21.0-rc0@d99803e and rebar3.4.5 now compiles on Erlang21

### DIFF
--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -1,12 +1,12 @@
 FROM buildpack-deps:stretch
 
-ENV OTP_VERSION="21.0-rc0@1b18005"
+ENV OTP_VERSION="21.0-rc0@d99803e"
 
 # We'll install the build dependencies for erlang-odbc along with the erlang
 # build process:
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/${OTP_VERSION#*@}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="f9d1ac3ad8406bdbc5afc32a2ff98e362d18697041907ff998b6af7d9f3d195d" \
+	&& OTP_DOWNLOAD_SHA256="9112e34162a0a30cc4dd9e7633d74d0cffbdc4b1ae191ccaa62fc12d8340c5a6" \
 	&& curl -fSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
 	&& echo "$OTP_DOWNLOAD_SHA256 otp-src.tar.gz" | sha256sum -c - \
 	&& runtimeDeps='libodbc1 \
@@ -53,17 +53,17 @@ RUN set -xe \
 	&& install -v ./rebar /usr/local/bin/ \
 	&& rm -rf /usr/src/rebar-src
 
-ENV REBAR3_VERSION="3.4.4"
+ENV REBAR3_VERSION="3.4.5"
 
 RUN set -xe \
 	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
-	&& REBAR3_DOWNLOAD_SHA256="0f7c860489dc4e4fcdc706a04690f791755870ff0e0582525b8ee9a78e911443" \
+	&& REBAR3_DOWNLOAD_SHA256="c2a72171c780153b45f29830d116d3dbec80666bbdec9b433c18619257ce3444" \
 	&& curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
 	&& echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/src/rebar3-src \
 	&& tar -xzf rebar3-src.tar.gz -C /usr/src/rebar3-src --strip-components=1 \
 	&& rm rebar3-src.tar.gz \
 	&& cd /usr/src/rebar3-src \
-	&& HOME=$PWD ./bootstrap || true \
-	&& install -v ./rebar3 /usr/local/bin/ || true \
+	&& HOME=$PWD ./bootstrap \
+	&& install -v ./rebar3 /usr/local/bin/ \
 	&& rm -rf /usr/src/rebar3-src

--- a/master/alpine/Dockerfile
+++ b/master/alpine/Dockerfile
@@ -1,10 +1,10 @@
 FROM alpine:3.6
 
-ENV OTP_VERSION="21.0-rc0@1b18005"
+ENV OTP_VERSION="21.0-rc0@d99803e"
 
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/${OTP_VERSION#*@}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="f9d1ac3ad8406bdbc5afc32a2ff98e362d18697041907ff998b6af7d9f3d195d" \
+	&& OTP_DOWNLOAD_SHA256="9112e34162a0a30cc4dd9e7633d74d0cffbdc4b1ae191ccaa62fc12d8340c5a6" \
 	&& apk add --no-cache --virtual .fetch-deps \
 		curl \
 		ca-certificates \


### PR DESCRIPTION
this update for next erlang-otp-21 @ master only so far, together with rebar3 is now able to compile on Erlang21 erlang/rebar3#1660 I don't think necessary to update major erlang images at https://hub.docker.com/_/erlang/ for every rebar releases, basically it's a maintenance effort + time thing, 
focusing on major Erlang releases is the most important, others are optional; but if anyone here want to make PR for that I do not object either /cc @getong