### PR TITLE
fix the libssl dependency updates in debian:stretch is libssl1.1

### DIFF
--- a/20/slim/Dockerfile
+++ b/20/slim/Dockerfile
@@ -16,7 +16,7 @@ RUN set -xe \
 	&& echo "$OTP_DOWNLOAD_SHA256  otp-src.tar.gz" | sha256sum -c - \
 	&& runtimeDeps=' \
 		libodbc1 \
-		libssl1.0.2 \
+		libssl1.1 \
 		libsctp1 \
 	' \
 	&& buildDeps=' \


### PR DESCRIPTION
Resolves #121 

Reproduce of #121 is current latest `erlang:slim` unable to load crypto / ssl libraries

```console
$ docker run -it --rm erlang:slim erl -s crypto -s inets -s ssl
Erlang/OTP 20 [erts-9.3] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:10] [hipe] [kernel-poll:false]

{"init terminating in do_boot",{undef,[{crypto,start,[],[]},{init,start_em,1,[]},{init,do_boot,3,[]}]}}
init terminating in do_boot ({undef,[{crypto,start,[],[]},{init,start_em,1,[]},{init,do_boot,3,[]}]})

Crash dump is being written to: erl_crash.dump...done
```

but from a local build with this is able to crypto ssl again:

```console
$ docker run -it --rm otp:20-slim erl -s crypto -s inets -s ssl
Erlang/OTP 20 [erts-9.3] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:10] [hipe] [kernel-poll:false]

Eshell V9.3  (abort with ^G)
1> 
1> application:loaded_applications().
[{stdlib,"ERTS  CXC 138 10","3.4.5"},
 {ssl,"Erlang/OTP SSL application","8.2.5"},
 {inets,"INETS  CXC 138 49","6.5"},
 {public_key,"Public key infrastructure","1.5.2"},
 {crypto,"CRYPTO","4.2.1"},
 {asn1,"The Erlang ASN1 compiler version 5.0.5","5.0.5"},
 {kernel,"ERTS  CXC 138 10","5.4.3"}]
```